### PR TITLE
fix broken import

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -388,14 +388,6 @@ module.exports._enoent = enoent;
 
 /***/ }),
 
-/***/ 26:
-/***/ (function(module) {
-
-module.exports = eval("require")("./repo-context");
-
-
-/***/ }),
-
 /***/ 34:
 /***/ (function(module) {
 
@@ -8963,7 +8955,7 @@ module.exports = (promise, onFinally) => {
 const core = __webpack_require__(470);
 
 const octokit = __webpack_require__(930);
-const { repo, owner } = __webpack_require__(26);
+const { repo, owner } = __webpack_require__(656);
 
 const pullNumberRegex = new RegExp("^Merge pull request #([0-9]+)");
 

--- a/modules/get-pull_request-merges-between-commits.js
+++ b/modules/get-pull_request-merges-between-commits.js
@@ -1,7 +1,7 @@
 const core = require("@actions/core");
 
 const octokit = require("./octokit");
-const { repo, owner } = require("./repo-context");
+const { repo, owner } = require("./context");
 
 const pullNumberRegex = new RegExp("^Merge pull request #([0-9]+)");
 


### PR DESCRIPTION
# Issue

## Description

- action wasn't starting

## Changelog

### Fixed

- action was not starting because of a wrong require name in `modules\get-pull_request-merges-between-commits.js`. Changes `./repo-context` to `./context`
